### PR TITLE
Fix error response in trading route

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -244,7 +244,7 @@ def trade_post():
     saved = new_trade.save_and_commit()
 
     if saved is False:
-        return jsonify()({
+        return jsonify({
             "msg": "Data Base error"
         }), 500
 


### PR DESCRIPTION
## Summary
- fix server error response in `/user/trade` route

## Testing
- `flake8 src/api/routes.py` *(fails: multiple style violations)*

------
https://chatgpt.com/codex/tasks/task_e_68524ccaf64c832c81ba06a58a2a0285